### PR TITLE
Fix Windows build problems around Erlang upgrades

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -1,9 +1,3 @@
-!IF [where /Q Makefile.auto.win]
-# The file doesn't exist, so don't include it.
-!ELSE
-!INCLUDE Makefile.auto.win
-!ENDIF
-
 BCRYPT_PATH = c_src
 
 NMAKE = nmake /$(MAKEFLAGS)
@@ -19,14 +13,5 @@ all: comeonin
 comeonin:
 	$(MIX) compile
 
-Makefile.auto.win:
-	echo # Auto-generated as part of Makefile.win, do not modify. > $@
-	erl -eval "io:format(\"~s~n\", [lists:concat([\"ERTS_INCLUDE_PATH=\", code:root_dir(), \"/erts-\", erlang:system_info(version), \"/include\"])])" -s init stop -noshell >> $@
-
-!IFDEF ERTS_INCLUDE_PATH
 priv\bcrypt_nif.dll:
-	($(CC) $(CFLAGS) /I"$(ERTS_INCLUDE_PATH)" /LD /MD /Fe$@ $(NIF_SRC) && del Makefile.auto.win) || del Makefile.auto.win
-!ELSE
-priv\bcrypt_nif.dll: Makefile.auto.win
-	$(NMAKE) /F Makefile.win priv\bcrypt_nif.dll
-!ENDIF
+	$(CC) $(CFLAGS) /I"$(ERTS_INCLUDE_PATH)" /LD /MD /Fe$@ $(NIF_SRC)

--- a/Makefile.win
+++ b/Makefile.win
@@ -25,7 +25,7 @@ Makefile.auto.win:
 
 !IFDEF ERTS_INCLUDE_PATH
 priv\bcrypt_nif.dll:
-	$(CC) $(CFLAGS) /I"$(ERTS_INCLUDE_PATH)" /LD /MD /Fe$@ $(NIF_SRC)
+	($(CC) $(CFLAGS) /I"$(ERTS_INCLUDE_PATH)" /LD /MD /Fe$@ $(NIF_SRC) && del Makefile.auto.win) || del Makefile.auto.win
 !ELSE
 priv\bcrypt_nif.dll: Makefile.auto.win
 	$(NMAKE) /F Makefile.win priv\bcrypt_nif.dll

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,9 @@ defmodule Mix.Tasks.Compile.Comeonin do
     File.mkdir("priv")
     {exec, args} = case :os.type do
       {:win32, _} ->
-        {"nmake", ["/F", "Makefile.win", "priv\\bcrypt_nif.dll"]}
+        erts_include_path = "#{:code.root_dir()}/erts-#{:erlang.system_info(:version)}/include"
+        # note, the && must come immediately after the include path, no whitespace
+        {"cmd", ["/c set ERTS_INCLUDE_PATH=#{erts_include_path}&& nmake /F Makefile.win priv\\bcrypt_nif.dll"]}
       {:unix, os} when os in [:freebsd, :openbsd] ->
         {"gmake", ["priv/bcrypt_nif.so"]}
       _ ->


### PR DESCRIPTION
As discussed in https://github.com/riverrun/comeonin/issues/92.

As requested, here's a PR that I expect fixes Windows build across Erlang upgrades. Note that my make/nmake knowledge is pretty much nonexistent so I wrote it like I'd write a batch/bash file. I suspect there is a nicer, makefile-ish way, to do this.

Wondering what you think. If you also think this is good, I'll submit a similar change to the Elixir C interop wiki where I suspect you got the Makefile.win from.

Thanks for a great library!