### PR TITLE
Update dialyze --plt command and update dialyzer config to remove unknown warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ otp_release:
 sudo: false
 script:
   - mix test
-  - mix dialyzer.plt
+  - mix dialyzer --plt
   - mix dialyzer --halt-exit-status
 after_script:
   - mix deps.get --only docs

--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Comeonin.Mixfile do
      source_url: "https://github.com/riverrun/comeonin",
      compilers: [:elixir_make] ++ Mix.compilers,
      deps: deps(),
-     dialyzer: [plt_file: ".dialyzer/local.plt"]]
+     dialyzer: [plt_file: ".dialyzer/local.plt", remove_defaults: [:unknown]]]
   end
 
   def application do


### PR DESCRIPTION
Fix the failing travis build which casued by `dialyxir` update.

Changes of `dialyxir`:
[Eliminate separate plt task](https://github.com/jeremyjh/dialyxir/commit/cc940aebdb6ce0306bf10f28bd2f5932460aca2d)
[Disabled warnings about unknown functions](https://github.com/jeremyjh/dialyxir#ignore-warnings)