### PR TITLE
Make README clearer on having to install sub deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,30 @@ Comeonin supports Argon2, Bcrypt and Pbkdf2 (sha512 and sha256).
 
 ## Installation and Use
 
-See the [Comeonin wiki](https://github.com/riverrun/comeonin/wiki) for details.
+First, you need to decide which algorithm to use (see the
+`Choosing an algorithm` section for more information about
+each algorithm):
+
+    * Argon2 - [argon2_elixir](https://github.com/riverrun/argon2_elixir)
+    * Bcrypt - [bcrypt_elixir](https://github.com/riverrun/bcrypt_elixir)
+    * Pbkdf2 - [pbkdf2_elixir](https://github.com/riverrun/pbkdf2_elixir)
+
+If you choose Argon2 or Bcrypt, you will need to have a C compiler
+installed. Argon2 also requires dirty scheduler support, which is
+provided by default in Erlang 20. You do not need to have a C compiler
+installed to use Pbkdf2.
+
+Then add `comeonin` and the library you choose to the `deps` section
+of your `mix.exs` file, as in the following example.
+
+      defp deps do
+        [
+          {:comeonin, "~> 4.0"},
+          {:bcrypt_elixir, "~> 0.12.0"},
+        ]
+      end
+
+For more information see the [Comeonin wiki](https://github.com/riverrun/comeonin/wiki) for details.
 
 ### Documentation
 


### PR DESCRIPTION
It would be nice to have the installation details directly in the README, otherwise they are very easy to miss. 