### PR TITLE
Remove "Docs" link from mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -40,8 +40,7 @@ defmodule Comeonin.Mixfile do
     [
       maintainers: ["David Whitlock"],
       licenses: ["BSD"],
-      links: %{"GitHub" => "https://github.com/riverrun/comeonin",
-        "Docs" => "http://hexdocs.pm/comeonin"}
+      links: %{"GitHub" => "https://github.com/riverrun/comeonin"}
     ]
   end
 end


### PR DESCRIPTION
Hex.pm already adds "Online documentation" link if docs are present