### PR TITLE
Make sure hash_key is always used when passed

### DIFF
--- a/lib/comeonin/base.ex
+++ b/lib/comeonin/base.ex
@@ -171,8 +171,8 @@ for {module, alg} <- [{Argon2, "Argon2"}, {Bcrypt, "Bcrypt"}, {Pbkdf2, "Pbkdf2"}
       """
       defdelegate dummy_checkpw(opts \\ []), to: module, as: :no_user_verify
 
-      defp get_hash(%{password_hash: hash}, _), do: {:ok, hash}
-      defp get_hash(%{encrypted_password: hash}, _), do: {:ok, hash}
+      defp get_hash(%{password_hash: hash}, nil), do: {:ok, hash}
+      defp get_hash(%{encrypted_password: hash}, nil), do: {:ok, hash}
       defp get_hash(_, nil), do: nil
       defp get_hash(user, hash_key), do: Map.get(user, hash_key) |> get_hash()
 


### PR DESCRIPTION
In my application, I use the `check_pass` method for both checking the _password_ hash and the _reset token_ hash. It seems that when the password_hash is present on the user struct, the `get_hash` method always returns this value. With this PR, the passed _hash_key_ is always used even if the _password_hash_ is present.