### PR TITLE
Minor docs cleanup

### DIFF
--- a/lib/comeonin.ex
+++ b/lib/comeonin.ex
@@ -48,14 +48,32 @@ defmodule Comeonin do
 
   The following is an example of calling this function with no options:
 
-    def verify_user(%{"password" => password} = params) do
-      params
-      |> Accounts.get_by()
-      |> check_pass(password)
-    end
+  ```elixir
+  def verify_user(%{"password" => password} = params) do
+    params
+    |> Accounts.get_by()
+    |> check_pass(password)
+  end
+  ```
 
   The `Accounts.get_by` function in this example takes the user parameters
   (for example, email and password) as input and returns a user struct or nil.
+
+  If your user map stores the password in the key `:pw_hash` instead of the
+  default `password`, you can do
+
+  ```elixir
+  case check_pass(user, hash_key: :pw_hash) do
+    {:ok, user} ->
+      # user is not nil and the password is verified
+      {:ok, user}
+
+    {:error, msg} ->
+      # User was nil or the password did not hash to the value in :pw_hash.
+      # The string value of msg will tell you which.
+      {:error, msg}
+  end
+  ```
   """
   @callback check_pass(user_struct, password, opts) :: {:ok, map} | {:error, String.t()}
 

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Comeonin.Mixfile do
 
   defp deps do
     [
-      {:ex_doc, "~> 0.19", only: :dev, runtime: false},
+      {:ex_doc, "~> 0.20", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0.0-rc.3", only: :dev, runtime: false}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
 %{
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.4", "71b42f5ee1b7628f3e3a6565f4617dfb02d127a0499ab3e72750455e986df001", [:mix], [{:erlex, "~> 0.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
-  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
   "erlex": {:hex, :erlex, "0.2.1", "cee02918660807cbba9a7229cae9b42d1c6143b768c781fa6cee1eaf03ad860b", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},


### PR DESCRIPTION
This fixes the formatting around the `check_pass/3 function, where the current rendering is a little bit off in the hex.pm docs. I also added a second example, since a lot of people may be using this as the basis for how they write their own code.

Also updates to the latest version of ex_docs.